### PR TITLE
Fix the crash caused by moving the ground plane

### DIFF
--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -2448,14 +2448,12 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
                  << std::endl;
           return true;
         }
-        // Check if the model is static or ground_plane
+        // Check if the model is ground_plane
         // If so, we refuse to set the pose
-        auto staticComp = _ecm.Component<components::Static>(_entity);
         auto nameComp = _ecm.Component<components::Name>(_entity);
-        if ((staticComp && staticComp->Data()) ||
-            (nameComp && nameComp->Data() == "ground_plane"))
+        if ((nameComp && nameComp->Data() == "ground_plane"))
         {
-          gzerr << "Refusing to set pose for static or ground_plane entity: "
+          gzerr << "Refusing to set pose for ground_plane entity: "
                 << (nameComp ? nameComp->Data() : "") << std::endl;
           return true;
         }

--- a/src/systems/physics/Physics.cc
+++ b/src/systems/physics/Physics.cc
@@ -2448,7 +2448,17 @@ void PhysicsPrivate::UpdatePhysics(EntityComponentManager &_ecm)
                  << std::endl;
           return true;
         }
-
+        // Check if the model is static or ground_plane
+        // If so, we refuse to set the pose
+        auto staticComp = _ecm.Component<components::Static>(_entity);
+        auto nameComp = _ecm.Component<components::Name>(_entity);
+        if ((staticComp && staticComp->Data()) ||
+            (nameComp && nameComp->Data() == "ground_plane"))
+        {
+          gzerr << "Refusing to set pose for static or ground_plane entity: "
+                << (nameComp ? nameComp->Data() : "") << std::endl;
+          return true;
+        }
         // TODO(addisu) Store the free group instead of searching for it at
         // every iteration
         auto freeGroup = modelPtrPhys->FindFreeGroup();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #2605 

## Summary
This crash occurs due to an attempt to move the groud_plane, and according to the comment on this [issue](https://github.com/gazebosim/gz-sim/issues/2605), we need to detect if the moving object is ground_plane, and if so, prohibit it

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers